### PR TITLE
Deployment of Solace broker loads now works with the default "restricted" SCC

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Deploying a Solace PubSub+ Software Message Broker with **Security Enhancements** onto an OpenShift 3.10 or 3.11 platform
+# Deploying a Solace PubSub+ Software Message Broker with <b>Security Enhancements</b> onto an OpenShift 3.10 or 3.11 platform
 
 ## Difference to the master branch
 

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,12 @@
 # Deploying a Solace PubSub+ Software Message Broker with <i>Security Enhancements</i> onto an OpenShift 3.10 or 3.11 platform
 
-## Difference to the master branch
+## Differences to the "master" branch
 
 In this QuickStart the message broker gets deployed in an unprivileged container without any additional [Linux capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html ) required. Compare with section [Running the message broker in unprivileged container](https://github.com/SolaceProducts/solace-openshift-quickstart#running-the-message-broker-in-unprivileged-container ) in the master branch.
 
-This requires a Solace PubSub+ build which supports the security enhancements. A compatible build can be obtained through Solace Support.
+The main difference to the master branch is that the `prepareProject.sh` script is not creating an SCC to open up above additional capabilities. This quickstart also requires the use of the "SecurityEnhancements" branch of the Kubernetes quickstart - see [Step 6](#step-6-option-1-deploy-the-message-broker-using-the-solace-kubernetes-quickstart). 
+
+This feature requires a Solace PubSub+ build which supports the security enhancements. A compatible build can be obtained through Solace Support.
 
 ## Purpose of this Repository
 
@@ -192,7 +194,7 @@ If you require more flexibility in terms of message broker deployment options (c
 
 * Retrieve the Solace Kubernetes QuickStart from GitHub:
 
-Important: notice the use of the "SecurityEnhancements" branch below. The "master" branch is not compatible with the changes for OpenShift Security Enhancements.
+**Important**: notice the use of the "SecurityEnhancements" branch below. The "master" branch is not compatible with the changes for OpenShift Security Enhancements.
 
 ```
 cd ~/workspace

--- a/readme.md
+++ b/readme.md
@@ -104,10 +104,12 @@ oc login
 
 * The Solace OpenShift QuickStart project contains useful scripts to help you prepare an OpenShift project for message broker deployment. Retrieve the project in your selected host:
 
+**Important**: notice the use of the "SecurityEnhancements" branch below. The "master" branch is not compatible with the changes for OpenShift Security Enhancements.
+
 ```
 mkdir ~/workspace
 cd ~/workspace
-git clone https://github.com/SolaceProducts/solace-openshift-quickstart.git
+git clone https://github.com/SolaceProducts/solace-openshift-quickstart.git -b SecurityEnhancements
 cd solace-openshift-quickstart
 ```
 
@@ -169,12 +171,11 @@ Deployment scripts will pull the Solace message broker image from a [Docker regi
   * You can choose to use [OpenShift's Docker registry.](https://docs.openshift.com/container-platform/3.10/install_config/registry/deploy_registry_existing_clusters.html )
 
   * **(Optional / ECR)** You can utilize the AWS Elastic Container Registry (ECR) to host the message broker Docker image. For more information, refer to [Amazon Elastic Container Registry](https://aws.amazon.com/ecr/ ). If you are using ECR as your Docker registry then you must add the ECR login credentials (as an OpenShift secret) to your message broker HA deployment.  This project contains a helper script to execute this step:
-
 ```
 # Required if using ECR for Docker registry
 cd ~/workspace/solace-openshift-quickstart/scripts
 sudo su
-aws configure       # provide AWS config for root
+aws configure       # provide AWS config for root; provide your keys, leave the rest to None.
 ./addECRsecret.sh solace-pubsub   # adjust your project name as needed
 ```
   Here is an outline of the additional steps required if loading an image to ECR:

--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ Deployment scripts will pull the Solace message broker image from a [Docker regi
     # Required if using ECR for Docker registry
     cd ~/workspace/solace-openshift-quickstart/scripts
     sudo su
-    aws configure       # provide AWS config for root; provide your keys, leave the rest to None.
+    aws configure       # provide AWS config for root; provide your key ID and key, leave the rest to None.
     ./addECRsecret.sh solace-pubsub   # adjust your project name as needed
 ```
   Here is an outline of the additional steps required if loading an image to ECR:

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Deploying a Solace PubSub+ Software Message Broker with Security Enhancements onto an OpenShift 3.10 or 3.11 platform
+# Deploying a Solace PubSub+ Software Message Broker with **Security Enhancements** onto an OpenShift 3.10 or 3.11 platform
 
 ## Difference to the master branch
 

--- a/readme.md
+++ b/readme.md
@@ -192,9 +192,11 @@ If you require more flexibility in terms of message broker deployment options (c
 
 * Retrieve the Solace Kubernetes QuickStart from GitHub:
 
+Important: notice the use of the "SecurityEnhancements" branch below. The "master" branch is not compatible with the changes for OpenShift Security Enhancements.
+
 ```
 cd ~/workspace
-git clone https://github.com/SolaceProducts/solace-kubernetes-quickstart.git
+git clone https://github.com/SolaceProducts/solace-kubernetes-quickstart.git -b SecurityEnhancements
 cd solace-kubernetes-quickstart
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Differences to the "master" branch
 
-In this QuickStart the message broker gets deployed in an unprivileged container without any additional [Linux capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html ) required. Compare with section [Running the message broker in unprivileged container](https://github.com/SolaceProducts/solace-openshift-quickstart#running-the-message-broker-in-unprivileged-container ) in the master branch.
+In this "SecurityEnhancements" branch of the OpenShift QuickStart the message broker gets deployed in an unprivileged container without any additional [Linux capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html ) required. Compare with section [Running the message broker in unprivileged container](https://github.com/SolaceProducts/solace-openshift-quickstart#running-the-message-broker-in-unprivileged-container ) in the "master" branch.
 
 The main difference to the master branch is that the `prepareProject.sh` script is not creating an SCC to open up above additional capabilities. This quickstart also requires the use of the "SecurityEnhancements" branch of the Kubernetes quickstart - see [Step 6](#step-6-option-1-deploy-the-message-broker-using-the-solace-kubernetes-quickstart). 
 

--- a/readme.md
+++ b/readme.md
@@ -171,12 +171,12 @@ Deployment scripts will pull the Solace message broker image from a [Docker regi
   * You can choose to use [OpenShift's Docker registry.](https://docs.openshift.com/container-platform/3.10/install_config/registry/deploy_registry_existing_clusters.html )
 
   * **(Optional / ECR)** You can utilize the AWS Elastic Container Registry (ECR) to host the message broker Docker image. For more information, refer to [Amazon Elastic Container Registry](https://aws.amazon.com/ecr/ ). If you are using ECR as your Docker registry then you must add the ECR login credentials (as an OpenShift secret) to your message broker HA deployment.  This project contains a helper script to execute this step:
-```
-# Required if using ECR for Docker registry
-cd ~/workspace/solace-openshift-quickstart/scripts
-sudo su
-aws configure       # provide AWS config for root; provide your keys, leave the rest to None.
-./addECRsecret.sh solace-pubsub   # adjust your project name as needed
+```shell
+    # Required if using ECR for Docker registry
+    cd ~/workspace/solace-openshift-quickstart/scripts
+    sudo su
+    aws configure       # provide AWS config for root; provide your keys, leave the rest to None.
+    ./addECRsecret.sh solace-pubsub   # adjust your project name as needed
 ```
   Here is an outline of the additional steps required if loading an image to ECR:
   

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Deploying a Solace PubSub+ Software Message Broker with <b>Security Enhancements</b> onto an OpenShift 3.10 or 3.11 platform
+# Deploying a Solace PubSub+ Software Message Broker with <i>Security Enhancements</i> onto an OpenShift 3.10 or 3.11 platform
 
 ## Difference to the master branch
 

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,10 @@
-# Deploying a Solace PubSub+ Software Message Broker onto an OpenShift 3.10 or 3.11 platform
+# Deploying a Solace PubSub+ Software Message Broker with Security Enhancements onto an OpenShift 3.10 or 3.11 platform
+
+## Difference to the master branch
+
+In this QuickStart the message broker gets deployed in an unprivileged container without any additional [Linux capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html ) required. Compare with section [Running the message broker in unprivileged container](https://github.com/SolaceProducts/solace-openshift-quickstart#running-the-message-broker-in-unprivileged-container ) in the master branch.
+
+This requires a Solace PubSub+ build which supports the security enhancements. A compatible build can be obtained through Solace Support.
 
 ## Purpose of this Repository
 
@@ -464,17 +470,7 @@ Now the OpenShift stack delete can be initiated from the AWS CloudFormation cons
 
 ## Special topics
 
-### Running the message broker in unprivileged container
-
-In this QuickStart the message broker gets deployed in an unprivileged container with necessary additional fine-grained [Linux capabilities](http://man7.org/linux/man-pages/man7/capabilities.7.html ) opened up that are required by the broker operation.
-
-To deploy the message broker in unprivileged container the followings are required and are already taken care of by the scripts:
-
-* A custom [OpenShift SCC](https://docs.openshift.com/container-platform/3.10/architecture/additional_concepts/authorization.html#security-context-constraints ) defining the fine grained permissions above the "restricted" SCC needs to be created and assigned to the deployment user of the project. See the [sccForUnprivilegedCont.yaml](https://github.com/SolaceProducts/solace-openshift-quickstart/blob/master/scripts/templates/sccForUnprivilegedCont.yaml ) file in this repo. 
-* The requested `securityContext` for the container shall be `privileged: false`
-* Additionally, any privileged ports (port numbers less than 1024) used need to be reconfigured. For example, port 22 for SSH access needs to be reconfigured to e.g.: 22222. Note that this is at the pod level and the load balancer has been configured to expose SSH at port 22 at the publicly accessible Solace Connection URI.
-
-### Using NFS for persitent storage
+### Using NFS for persistent storage
 
 The Solace PubSub+ message broker supports NFS for persistent storage, with "root_squash" option configured on the NFS server.
 

--- a/readme.md
+++ b/readme.md
@@ -164,14 +164,14 @@ Deployment scripts will pull the Solace message broker image from a [Docker regi
 
 ```
 # Required if using ECR for Docker registry
+cd ~/workspace/solace-openshift-quickstart/scripts
 sudo su
 aws configure       # provide AWS config for root
-cd ~/workspace/solace-openshift-quickstart/scripts
 ./addECRsecret.sh solace-pubsub   # adjust your project name as needed
 ```
   Here is an outline of the additional steps required if loading an image to ECR:
   
-  * Copy the Solace Docker image location and download the image archive locally using the `wget <url>` command.
+  * Copy the Solace Docker image location url and download the image archive locally using the `wget <url>` command.
   * Load the downloaded image to the local docker image repo using the `docker load -i <archive>` command
   * Go to your target ECR repository in the [AWS ECR Repositories console](https://console.aws.amazon.com/ecr ) and get the push commands information by clicking on the "View push commands" button.
   * Start from the `docker tag` command to tag the image you just loaded. Use `docker images` to find the  Solace Docker image just loaded. You may need to use 

--- a/scripts/prepareProject.sh
+++ b/scripts/prepareProject.sh
@@ -53,8 +53,9 @@ fi
 # Configure the required OpenShift Policies and SCC privileges for the operation of the Solace message router software
 echo "Granting the ${1} project policies and SCC privileges for correct operation..."
 oc policy add-role-to-user edit system:serviceaccount:$PROJECT:default
-echo "Setting up deployment in unprivileged container:"
-oc create -f templates/sccForUnprivilegedCont.yaml
-oc adm policy add-scc-to-user scc-solace-in-unprivileged-container system:serviceaccount:$PROJECT:default
+# Followings are no longer required when using a Solace PubSub+ build with security enhancements
+#echo "Setting up deployment in unprivileged container:"
+#oc create -f templates/sccForUnprivilegedCont.yaml
+#oc adm policy add-scc-to-user scc-solace-in-unprivileged-container system:serviceaccount:$PROJECT:default
 oc adm policy add-cluster-role-to-user storage-admin admin
 

--- a/templates/messagebroker_ha_template.yaml
+++ b/templates/messagebroker_ha_template.yaml
@@ -484,24 +484,6 @@ objects:
               - "7"
           securityContext:
             privileged: false
-            capabilities:
-              add:
-                - IPC_LOCK
-                - SYS_NICE
-                - SETPCAP
-                - MKNOD
-                - AUDIT_WRITE
-                - CHOWN
-                - NET_RAW
-                - DAC_OVERRIDE
-                - FOWNER
-                - FSETID
-                - KILL
-                - SETGID
-                - SETUID
-                - NET_BIND_SERVICE
-                - SYS_CHROOT
-                - SETFCAP
           env:
           - name: STATEFULSET_NAME
             value: "${DEPLOYMENT_NAME}-solace"
@@ -546,8 +528,11 @@ objects:
             mountPath: /usr/sw/adb
             subPath: adb
           - name: data
+            mountPath: /var/lib/solace/diags
+            subPath: diags
+          - name: data
             mountPath: /usr/sw/internalSpool/softAdb
-            subPath: softAdb
+            subPath: softAdb #end !nfs
           ports:
           - containerPort: 2222
             protocol: TCP

--- a/templates/messagebroker_singlenode_template.yaml
+++ b/templates/messagebroker_singlenode_template.yaml
@@ -275,24 +275,6 @@ objects:
               - "7"
           securityContext:
             privileged: false
-            capabilities:
-              add:
-                - IPC_LOCK
-                - SYS_NICE
-                - SETPCAP
-                - MKNOD
-                - AUDIT_WRITE
-                - CHOWN
-                - NET_RAW
-                - DAC_OVERRIDE
-                - FOWNER
-                - FSETID
-                - KILL
-                - SETGID
-                - SETUID
-                - NET_BIND_SERVICE
-                - SYS_CHROOT
-                - SETFCAP
           env:
           - name: STATEFULSET_NAME
             value: "${DEPLOYMENT_NAME}-solace"
@@ -337,8 +319,11 @@ objects:
             mountPath: /usr/sw/adb
             subPath: adb
           - name: data
+            mountPath: /var/lib/solace/diags
+            subPath: diags
+          - name: data
             mountPath: /usr/sw/internalSpool/softAdb
-            subPath: softAdb
+            subPath: softAdb #end !nfs
           ports:
           - containerPort: 2222
             protocol: TCP


### PR DESCRIPTION
- It is no longer required to open up linux capabilities, i.e. to use the SCC scc-solace-in-unprivileged-container
- Updated documentation to reflect the security enhancements